### PR TITLE
Implement persistent secret key

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4913,6 +4913,7 @@ dependencies = [
  "iroh-blobs",
  "iroh-docs",
  "iroh-gossip",
+ "rand 0.8.5",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,11 +28,12 @@ iroh-docs = { version = "0.35.0", features = ["rpc"] }
 iroh-gossip = "0.35.0"
 machine = { path = "./machine" }
 manager = { path = "./manager" }
+n0-future = "0.1.3"
 quic-rpc = "0.20.0"
+rand = "0.8.5"
 serde = "1.0.219"
 serde_json = "1.0.140"
 shared = { path = "./shared" }
 tempfile = "3.20.0"
 tokio = { version = "1.45.0", features = ["macros", "rt"] }
 uuid = { version = "1.16.0", features = ["v4"] }
-n0-future = "0.1.3"

--- a/machine/Cargo.toml
+++ b/machine/Cargo.toml
@@ -14,10 +14,10 @@ fedimint-lnv2-common = { workspace = true }
 iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 iroh-docs = { workspace = true }
-quic-rpc = { workspace = true }
-shared = { workspace = true }
-serde_json = { workspace = true }
 n0-future = { workspace = true }
+quic-rpc = { workspace = true }
+serde_json = { workspace = true }
+shared = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]

--- a/manager/Cargo.toml
+++ b/manager/Cargo.toml
@@ -12,7 +12,8 @@ fedimint-core = { workspace = true }
 iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 iroh-docs = { workspace = true }
-uuid = { workspace = true }
 serde_json = { workspace = true }
 shared = { workspace = true }
 tokio = { workspace = true }
+uuid = { workspace = true }
+

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -14,4 +14,5 @@ iroh = { workspace = true }
 iroh-blobs = { workspace = true }
 iroh-docs = { workspace = true }
 iroh-gossip = { workspace = true }
+rand = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary
- save and load the machine secret key from the top-level storage folder
- keep dependencies sorted alphabetically
- reuse existing variable naming in new restart test

## Testing
- `cargo test --all --workspace`
