### PR TITLE
feat: decouple invoice creation from payment await

### DIFF
--- a/vendimint-tests/bin/tests.rs
+++ b/vendimint-tests/bin/tests.rs
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
             tokio::time::sleep(Duration::from_secs(5)).await;
 
             println!("Machine generating invoice...");
-            let (invoice, final_state_receiver) = machine
+            let (invoice, operation_id) = machine
                 .receive_payment(
                     Amount::from_sats(1_000),
                     60,
@@ -94,8 +94,13 @@ async fn main() -> anyhow::Result<()> {
                 .pay_bolt11_invoice(invoice.to_string())
                 .await?;
 
+            println!("Waiting for payment to be received to machine...");
+            let final_payment_state = machine
+                .await_receive_payment_final_state(operation_id)
+                .await?;
+
             assert_eq!(
-                final_state_receiver.await?,
+                final_payment_state,
                 FinalRemoteReceiveOperationState::Funded
             );
 

--- a/vendimint/src/machine.rs
+++ b/vendimint/src/machine.rs
@@ -4,6 +4,7 @@ use crate::fedimint_wallet::Wallet;
 use crate::vendimint_iroh::MachineConfig;
 use crate::vendimint_iroh::MachineProtocol;
 use bitcoin::Network;
+use fedimint_client::OperationId;
 use fedimint_core::{Amount, util::SafeUrl};
 use fedimint_lnv2_common::Bolt11InvoiceDescription;
 use fedimint_lnv2_remote_client::FinalRemoteReceiveOperationState;
@@ -103,10 +104,7 @@ impl Machine {
         expiry_secs: u32,
         description: Bolt11InvoiceDescription,
         gateway: Option<SafeUrl>,
-    ) -> anyhow::Result<(
-        Bolt11Invoice,
-        oneshot::Receiver<FinalRemoteReceiveOperationState>,
-    )> {
+    ) -> anyhow::Result<(Bolt11Invoice, OperationId)> {
         let Some(machine_config) = self.iroh_protocol.get_machine_config().await? else {
             return Err(anyhow::anyhow!(
                 "Machine cannot accept payments as it is not configured"
@@ -122,6 +120,15 @@ impl Machine {
                 description,
                 gateway,
             )
+            .await
+    }
+
+    pub async fn await_receive_payment_final_state(
+        &self,
+        operation_id: OperationId,
+    ) -> anyhow::Result<FinalRemoteReceiveOperationState> {
+        self.wallet
+            .await_receive_payment_final_state(operation_id)
             .await
     }
 


### PR DESCRIPTION
Device generates bolt11 invoices using `receive_payment`, which returns an operation id alongside the invoice. Then it waits for the payment's completion using `await_receive_payment_final_state`, which accepts the operation id returned from `receive_payment`. This allows for the API caller to store the operation id before using the invoice, to allow for creation of state machines.